### PR TITLE
Updated clearBitmap to use bitmap fill builtin function

### DIFF
--- a/textmap.py
+++ b/textmap.py
@@ -244,12 +244,7 @@ class textBox:
         return (self._cursorX, self._cursorY)
 
     def clearBitmap(self):
-        import gc
-
-        for x in range(self._width):
-            for y in range(self._height):
-                self.bitmap[x, y] = 0
-        gc.collect()
+        self.bitmap.fill(0) # quick builtin bitmap fill operation 
         self.setCursor(self._startX, self._startY)
         if self._memorySaver == False: 
             self._text='' # reset the text string


### PR DESCRIPTION
I discovered that the `displayio.bitmap` structure includes an undocumented `.fill` function that is much faster than performing the operation up in the python layer. 

I removed the memory collection sections and modified the code to use this built-in `.fill` function.